### PR TITLE
Disable active_test in filtered_domain

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5519,7 +5519,7 @@ Fields:
             else:
                 (key, comparator, value) = d
                 if comparator in ('child_of', 'parent_of'):
-                    result.append(self.search([('id', 'in', self.ids), d]))
+                    result.append(self.with_context(active_test=False).search([('id', 'in', self.ids), d]))
                     continue
                 if key.endswith('.id'):
                     key = key[:-3]


### PR DESCRIPTION
If a domain contains child_of or parent_of operators, a new search is performed, but inactive records are lost, if active_test is not set in context (e.g. when records are browsed directly).